### PR TITLE
Release management with donderflow

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -140,7 +140,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         // BEGIN VERSIONS
         versionCode 3
-        versionName "1.0.0-alpha.2"
+        versionName "1.0.1-alpha.0"
         multiDexEnabled true
     }
     splits {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,6 +138,7 @@ android {
         applicationId "com.cloudoki.appdoki"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        // BEGIN VERSIONS
         versionCode 3
         versionName "1.0.0-alpha.2"
         multiDexEnabled true

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
   "name": "appdoki",
   "displayName": "appdoki",
-  "version": "1.0.0-alpha.2"
+  "version": "1.0.1-alpha.0"
 }

--- a/donderflow.json
+++ b/donderflow.json
@@ -1,0 +1,4 @@
+{
+  "allowBranch": ["master"],
+  "bumpFilesFunc": "scripts/bumpFiles"
+}

--- a/ios/appdoki/Info.plist
+++ b/ios/appdoki/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0-alpha.2</string>
+	<string>1.0.1-alpha.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appdoki-rn",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.1-alpha.0",
   "homepage": "https://github.com/Cloudoki/appdoki-rn.git#readme",
   "bugs": {
     "url": "https://github.com/Cloudoki/appdoki-rn/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "appdoki-rn",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
+  "homepage": "https://github.com/Cloudoki/appdoki-rn.git#readme",
+  "bugs": {
+    "url": "https://github.com/Cloudoki/appdoki-rn/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cloudoki/appdoki-rn.git"
+  },
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -70,6 +78,7 @@
     "eslint-plugin-react-hooks": "4.0.8",
     "eslint-plugin-react-native-globals": "0.1.2",
     "eslint-plugin-standard": "4.0.1",
+    "fs-extra": "9.0.1",
     "jest": "26.1.0",
     "metro-react-native-babel-preset": "0.60.0",
     "react-native-dotenv": "2.2.0",

--- a/scripts/bumpfiles.js
+++ b/scripts/bumpfiles.js
@@ -1,0 +1,101 @@
+const fse = require('fs-extra')
+
+module.exports = async (config) => {
+  return Promise.all([
+    bumpAppJson(config),
+    bumpIOS(config),
+    bumpAndroid(config),
+  ])
+}
+
+async function bumpAppJson ({ version }) {
+  const appJsonData = JSON.parse(fse.readFileSync('app.json', { encoding: 'utf8' }))
+  appJsonData.version = version
+
+  return fse.writeFile('app.json', JSON.stringify(appJsonData, null, 2) + '\n')
+}
+
+async function bumpIOS (config) {
+  const filePath = 'ios/appdoki/info.plist'
+  let body = await fse.readFile(filePath)
+
+  body = body.toString().split('\n')
+
+  let i = 0
+  const leng = body.length
+  let shortVersionLine = -1
+  let versionLine = -1
+  for (i; i < leng; i++) {
+    if (shortVersionLine < 0 && RegExp('<key>CFBundleShortVersionString</key>').test(body[i])) {
+      shortVersionLine = i + 1
+    }
+
+    if (versionLine < 0 && RegExp('<key>CFBundleVersion</key>').test(body[i])) {
+      versionLine = i + 1
+    }
+
+    if (shortVersionLine >= 0 && versionLine >= 0) {
+      break
+    }
+  }
+
+  if (shortVersionLine < 0 || versionLine < 0) {
+    throw new Error(`Could not find version lines on ${filePath}`)
+  }
+
+  const searchBegin = '<string>'
+  const searchEnd = '</string>'
+
+  const shortVersionText = body[shortVersionLine]
+  const shortVersion = shortVersionText.substring(
+    shortVersionText.indexOf(searchBegin) + searchBegin.length, shortVersionText.indexOf(searchEnd),
+  )
+
+  body[shortVersionLine] = body[shortVersionLine].replace(shortVersion, config.version)
+
+  const versionText = body[versionLine]
+  const version = Number(versionText.substring(
+    versionText.indexOf(searchBegin) + searchBegin.length, versionText.indexOf(searchEnd),
+  ))
+
+  // timestamp version
+  body[versionLine] = body[versionLine].replace(version, Date.now())
+
+  const output = body.join('\n')
+  return fse.writeFile(filePath, output)
+}
+
+async function bumpAndroid (config) {
+  const filePath = 'android/app/build.gradle'
+  let body = await fse.readFile(filePath)
+
+  body = body.toString().split('\n')
+
+  let i = 0
+  const leng = body.length
+  let beginVersionsLine = -1
+  for (i; i < leng; i++) {
+    if (RegExp('\\/\\/ BEGIN VERSIONS').test(body[i])) {
+      beginVersionsLine = i
+      break
+    }
+  }
+
+  if (beginVersionsLine < 0) {
+    throw new Error(`Could not find versions line on ${filePath}`)
+  }
+
+  const versionCodeLine = beginVersionsLine + 1
+  const versionNameLine = beginVersionsLine + 2
+
+  const versionCodeText = body[versionCodeLine]
+  const versionCode = Number(versionCodeText.substring(versionCodeText.lastIndexOf(' '), versionCodeText.length))
+  body[versionCodeLine] = body[versionCodeLine].replace(versionCode, versionCode + 1)
+
+  const versionNameText = body[versionNameLine]
+  const versionName = versionNameText.substring(versionNameText.lastIndexOf(' '), versionNameText.length)
+  body[versionNameLine] = body[versionNameLine].replace(versionName, ` "${config.version}"`)
+
+  const output = body.join('\n')
+  return fse.writeFile(filePath, output)
+}

--- a/scripts/bumpfiles.js
+++ b/scripts/bumpfiles.js
@@ -90,10 +90,13 @@ async function bumpAndroid (config) {
 
   const versionCodeText = body[versionCodeLine]
   const versionCode = Number(versionCodeText.substring(versionCodeText.lastIndexOf(' '), versionCodeText.length))
+
+  // Incremental version
   body[versionCodeLine] = body[versionCodeLine].replace(versionCode, versionCode + 1)
 
   const versionNameText = body[versionNameLine]
   const versionName = versionNameText.substring(versionNameText.lastIndexOf(' '), versionNameText.length)
+
   body[versionNameLine] = body[versionNameLine].replace(versionName, ` "${config.version}"`)
 
   const output = body.join('\n')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "index.js",
     "metro.config.js",
     "babel.config.js",
+    "scripts/bumpfiles.js",
 		"src/**/*"
 	],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3798,6 +3798,16 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+fs-extra@9.0.1, fs-extra@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-extra@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
@@ -3815,16 +3825,6 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
-  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Progress
- [x] add donderflow configuration for release management

To do a new release test, run:
`export GH_TOKEN=<TOKEN>; npx @cloudoki/donderflow@1.0.0-alpha.5 --preid alpha --dry-run`

NOTE: if you omit the `--dry-run` flag the release will be committed to origin and tags will follow.

closes #5 